### PR TITLE
Fix warning 'Restore cache failed'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,34 +4,34 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
       CGO_ENABLED: 0
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
     - name: Install Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v4
     - name: Test
       run: go test
 
   test-dynamic:
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
     - name: Install Go
       uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v4
     - name: Install package
       run: |
         sudo apt-get update -y; sudo apt-get -y install libwebp-dev


### PR DESCRIPTION
As seen e.g. [here](https://github.com/gen2brain/webp/actions/runs/9658972217), there are warnings when running `test` action:

```
Restore cache failed: Dependencies file is not found in /Users/runner/work/webp/webp.
Supported file pattern: go.sum
```

This PR fixes that issue.