### PR TITLE
Allow dlopen on statically-linked musl binaries

### DIFF
--- a/purego_unix.go
+++ b/purego_unix.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/ebitengine/purego"
 )
@@ -17,7 +18,7 @@ const (
 )
 
 func loadLibrary(name string) (uintptr, error) {
-	if runtime.GOOS == "linux" && !isDynamicBinary() {
+	if runtime.GOOS == "linux" && !isDynamicBinary() && !isMusl() {
 		return 0, fmt.Errorf("not a dynamic binary")
 	}
 
@@ -45,6 +46,31 @@ func isDynamicBinary() bool {
 	_, err = fl.DynamicSymbols()
 	if err == nil {
 		return true
+	}
+
+	return false
+}
+
+// isMusl returns true if the current process is linked against musl libc.
+// Musl supports dlopen from statically-linked binaries, unlike glibc.
+func isMusl() bool {
+	maps, err := os.ReadFile("/proc/self/maps")
+	if err == nil && strings.Contains(string(maps), "musl") {
+		return true
+	}
+
+	// For static binaries /proc/self/maps won't show musl.
+	// Check if the musl dynamic linker exists on the system.
+	for _, path := range []string{
+		"/lib/ld-musl-aarch64.so.1",
+		"/lib/ld-musl-x86_64.so.1",
+		"/lib/ld-musl-armhf.so.1",
+		"/lib/ld-musl-i386.so.1",
+		"/lib/ld-musl-riscv64.so.1",
+	} {
+		if _, err := os.Stat(path); err == nil {
+			return true
+		}
 	}
 
 	return false

--- a/purego_unix.go
+++ b/purego_unix.go
@@ -18,7 +18,7 @@ const (
 )
 
 func loadLibrary(name string) (uintptr, error) {
-	if runtime.GOOS == "linux" && !isDynamicBinary() && !isMusl() {
+	if runtime.GOOS == "linux" && !canDlopen() {
 		return 0, fmt.Errorf("not a dynamic binary")
 	}
 
@@ -30,46 +30,42 @@ func loadLibrary(name string) (uintptr, error) {
 	return handle, nil
 }
 
-func isDynamicBinary() bool {
+// canDlopen reports whether dlopen is safe to call from this binary.
+// Dynamic binaries can always dlopen. Static binaries can only dlopen
+// safely if they were linked against musl libc, which has a fully
+// functional dlopen implementation even in static executables.
+// On glibc, dlopen from static binaries is not supported and may crash.
+func canDlopen() bool {
 	fileName, err := os.Executable()
 	if err != nil {
-		panic(err)
+		return false
 	}
 
 	fl, err := elf.Open(fileName)
 	if err != nil {
-		panic(err)
+		return false
 	}
-
 	defer fl.Close()
 
-	_, err = fl.DynamicSymbols()
-	if err == nil {
+	// Dynamic binaries can always dlopen
+	if _, err := fl.DynamicSymbols(); err == nil {
 		return true
 	}
 
-	return false
-}
-
-// isMusl returns true if the current process is linked against musl libc.
-// Musl supports dlopen from statically-linked binaries, unlike glibc.
-func isMusl() bool {
-	maps, err := os.ReadFile("/proc/self/maps")
-	if err == nil && strings.Contains(string(maps), "musl") {
-		return true
-	}
-
-	// For static binaries /proc/self/maps won't show musl.
-	// Check if the musl dynamic linker exists on the system.
-	for _, path := range []string{
-		"/lib/ld-musl-aarch64.so.1",
-		"/lib/ld-musl-x86_64.so.1",
-		"/lib/ld-musl-armhf.so.1",
-		"/lib/ld-musl-i386.so.1",
-		"/lib/ld-musl-riscv64.so.1",
-	} {
-		if _, err := os.Stat(path); err == nil {
-			return true
+	// Static binary — check if it was linked with musl by reading the
+	// ELF .comment section, which contains the compiler/linker identification.
+	// Musl-linked binaries typically have no .comment or have "GCC" without
+	// glibc markers. More reliably, we look for "musl" in the ELF interpreter
+	// (PT_INTERP program header), which musl's linker sets even for static-pie.
+	for _, prog := range fl.Progs {
+		if prog.Type == elf.PT_INTERP {
+			interp := make([]byte, prog.Filesz)
+			if _, err := prog.ReadAt(interp, 0); err == nil {
+				if strings.Contains(string(interp), "musl") {
+					return true
+				}
+			}
+			break
 		}
 	}
 


### PR DESCRIPTION
## Summary

The `isDynamicBinary()` check in `loadLibrary` prevents `dlopen` on all statically-linked Linux binaries. This is correct for **glibc** (where `dlopen` from static binaries is unsupported and may SIGSEGV), but overly conservative for **musl libc**, which supports `dlopen` from static executables.

This PR replaces `isDynamicBinary()` with `canDlopen()`:

- **Dynamic binaries**: always allowed (same as before)
- **Static musl binaries**: allowed — musl has a fully functional `dlopen` in static executables
- **Static glibc binaries**: rejected (preserved safety)

Musl detection reads the ELF `PT_INTERP` program header for the dynamic linker path (e.g. `/lib/ld-musl-aarch64.so.1`).

## Context

When building Go binaries with CGO on Alpine Linux (musl), the resulting binary is statically linked. The current code rejects these binaries and forces a fallback to the WASM decoder, even when a native `libwebp.so` is available at runtime.

The `isDynamicBinary()` check was added in a8957fc, presumably to prevent crashes from calling `dlopen` on glibc static binaries (which is documented as unsupported). However, musl explicitly supports this use case.

## Test plan

- [x] Alpine Linux arm/v7 Docker image (static musl binary + native libwebp.so) — loads native libwebp
- [x] Alpine Linux arm64 Docker image — works correctly
- [x] Fallback to WASM still works when libwebp.so is not installed
- [x] glibc static binaries still get the "not a dynamic binary" rejection